### PR TITLE
chore: add min-release-age 7 days to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages: []
+release:
+  minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-packages: []
-release:
-  minimumReleaseAge: 10080


### PR DESCRIPTION
Prevents npm from installing packages published less than 7 days ago, reducing exposure to supply chain attacks.

Adds `min-release-age=7` to `.npmrc`.